### PR TITLE
Update composer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ To install the bindings via [Composer](https://getcomposer.org/), add the follow
     }
   ],
   "require": {
-    "j-mastr/sevdesk-php-sdk": "*@dev"
+    "itsmind/sevdesk-php-sdk": "*@dev"
   }
 }
 ```


### PR DESCRIPTION
The name of the package changed in the description file. To use the git head, you need to require the package name, not the github name.